### PR TITLE
Add search to mods portal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,7 @@ typings/
 
 # dotenv environment variables file
 .env
+
+# Lock files
+package-lock.json
+yarn.lock

--- a/src/renderer/components/ProfileViewPanel.vue
+++ b/src/renderer/components/ProfileViewPanel.vue
@@ -96,4 +96,8 @@ export default {
 }
 </script>
 
-<style lang="scss" scoped></style>
+<style lang="scss" scoped>
+ .profile-view-panel {
+     overflow-y: auto;
+ }
+</style>

--- a/src/renderer/pages/Portal.vue
+++ b/src/renderer/pages/Portal.vue
@@ -28,6 +28,7 @@
           </div>
 
           <div class="menu-section">
+            <input type="search" placeholder="Search..." class="search-mods" @change="setOnlineQuery($event.target.value); $event.target.focus()" />
             <button
               @click="fetchOnlineMods(true)"
               class="btn"
@@ -115,6 +116,7 @@ export default {
       onlineModsCurrentFilter: state => state.onlineModsCurrentFilter,
       onlineModsCurrentSort: state => state.onlineModsCurrentSort,
       username: state => state.username,
+      onlineQuery: state => state.onlineQuery,
     }),
     ...mapGetters(['maxPageOnlineMods']),
   },
@@ -130,9 +132,14 @@ export default {
       'fetchOnlineMods',
       'setCurrentOnlineModFilter',
       'setCurrentOnlineModSort',
+      'setOnlineQuery',
     ]),
   },
 }
 </script>
 
-<style lang="scss" scoped></style>
+<style lang="scss" scoped>
+ .search-mods {
+     margin-right: 15px;
+ }
+</style>

--- a/src/renderer/store/actions.js
+++ b/src/renderer/store/actions.js
@@ -55,6 +55,10 @@ export const setCurrentOnlineModSort = (context, sort) => {
   context.commit('SET_CURRENT_ONLINE_MOD_SORT', { onlineModsCurrentSort: sort })
 }
 
+export const setOnlineQuery = (context, query) => {
+  context.commit('SET_ONLINE_QUERY', { onlineQuery: query })
+}
+
 export const selectInstalledMod = (context, name) => {
   const mod = context.state.installedMods.find(m => m.name === name)
   context.commit('SET_SELECTED_MOD', { selectedMod: mod })

--- a/src/renderer/store/getters.js
+++ b/src/renderer/store/getters.js
@@ -12,11 +12,11 @@ export const filterModDependenciesByType = () => (mod, type = 'required') => {
   return mod.dependenciesParsed.filter(dependency => dependency.type === type)
 }
 
-export const search = (query, mods) => {
+export const search = (state, getters) => (query, mods) => {
   return mods.filter(mod => mod.title.toLowerCase().search(query.toLowerCase()) > -1)
 }
 
-export const currentlyDisplayedOnlineMods = (state) => {
+export const currentlyDisplayedOnlineMods = (state, getters) => {
   if (!state.onlineMods || !state.onlineMods.length === 0) return []
 
   let mods = state.onlineModsCurrentFilter === 'all'
@@ -25,7 +25,7 @@ export const currentlyDisplayedOnlineMods = (state) => {
 
   mods = state.onlineQuery === ''
     ? mods
-    : search(state.onlineQuery, mods)
+    : getters.search(state.onlineQuery, mods)
 
   const { onlineModsItemPerPage, onlineModsPage } = state
   const startIndex = onlineModsPage * onlineModsItemPerPage

--- a/src/renderer/store/getters.js
+++ b/src/renderer/store/getters.js
@@ -12,7 +12,6 @@ export const filterModDependenciesByType = () => (mod, type = 'required') => {
   return mod.dependenciesParsed.filter(dependency => dependency.type === type)
 }
 
-
 export const search = (query, mods) => {
   return mods.filter(mod => mod.title.toLowerCase().search(query.toLowerCase()) > -1)
 }
@@ -27,7 +26,6 @@ export const currentlyDisplayedOnlineMods = (state) => {
   mods = state.onlineQuery === ''
     ? mods
     : search(state.onlineQuery, mods)
-
 
   const { onlineModsItemPerPage, onlineModsPage } = state
   const startIndex = onlineModsPage * onlineModsItemPerPage

--- a/src/renderer/store/getters.js
+++ b/src/renderer/store/getters.js
@@ -56,12 +56,20 @@ export const currentlyDisplayedOnlineMods = (state, getters) => {
     .slice(startIndex, startIndex + onlineModsItemPerPage)
 }
 
-export const maxPageOnlineMods = (state) => {
+export const maxPageOnlineMods = (state, getters) => {
   if (!state.onlineMods || !state.onlineMods.length === 0) return 0
 
-  const count = state.onlineModsCurrentFilter === 'all'
+  let count = state.onlineModsCurrentFilter === 'all'
     ? state.onlineMods.length
     : state.onlineMods.filter(mod => mod.category === state.onlineModsCurrentFilter).length
+
+  let mods = state.onlineModsCurrentFilter === 'all'
+    ? state.onlineMods
+    : state.onlineMods.filter(mod => mod.category === state.onlineModsCurrentFilter)
+
+  count = state.onlineQuery === ''
+    ? count
+    : getters.search(state.onlineQuery, mods).length
 
   return Math.floor(count / state.onlineModsItemPerPage) - 1
 }

--- a/src/renderer/store/getters.js
+++ b/src/renderer/store/getters.js
@@ -12,12 +12,22 @@ export const filterModDependenciesByType = () => (mod, type = 'required') => {
   return mod.dependenciesParsed.filter(dependency => dependency.type === type)
 }
 
+
+export const search = (query, mods) => {
+  return mods.filter(mod => mod.title.toLowerCase().search(query.toLowerCase()) > -1)
+}
+
 export const currentlyDisplayedOnlineMods = (state) => {
   if (!state.onlineMods || !state.onlineMods.length === 0) return []
 
-  const mods = state.onlineModsCurrentFilter === 'all'
+  let mods = state.onlineModsCurrentFilter === 'all'
     ? state.onlineMods
     : state.onlineMods.filter(mod => mod.category === state.onlineModsCurrentFilter)
+
+  mods = state.onlineQuery === ''
+    ? mods
+    : search(state.onlineQuery, mods)
+
 
   const { onlineModsItemPerPage, onlineModsPage } = state
   const startIndex = onlineModsPage * onlineModsItemPerPage

--- a/src/renderer/store/getters.js
+++ b/src/renderer/store/getters.js
@@ -63,7 +63,7 @@ export const maxPageOnlineMods = (state, getters) => {
     ? state.onlineMods.length
     : state.onlineMods.filter(mod => mod.category === state.onlineModsCurrentFilter).length
 
-  let mods = state.onlineModsCurrentFilter === 'all'
+  const mods = state.onlineModsCurrentFilter === 'all'
     ? state.onlineMods
     : state.onlineMods.filter(mod => mod.category === state.onlineModsCurrentFilter)
 

--- a/src/renderer/store/index.js
+++ b/src/renderer/store/index.js
@@ -50,6 +50,7 @@ const state = {
   selectedMod: undefined,
   selectedOnlineMod: undefined,
   username: '',
+  onlineQuery: '',
 }
 
 Vue.use(Vuex)

--- a/src/renderer/store/mutations.js
+++ b/src/renderer/store/mutations.js
@@ -46,4 +46,5 @@ export const SET_ONLINE_MODS_PAGE = (state, payload) => {
 
 export const SET_ONLINE_QUERY = (state, payload) => {
   state.onlineQuery = payload.onlineQuery
+  state.onlineModsPage = 0
 }

--- a/src/renderer/store/mutations.js
+++ b/src/renderer/store/mutations.js
@@ -43,3 +43,7 @@ export const SET_SELECTED_ONLINE_MOD = (state, payload) => {
 export const SET_ONLINE_MODS_PAGE = (state, payload) => {
   state.onlineModsPage = payload.onlineModsPage
 }
+
+export const SET_ONLINE_QUERY = (state, payload) => {
+  state.onlineQuery = payload.onlineQuery
+}


### PR DESCRIPTION
This pull request adds the ability to search the mod portal. Going threw 2000+ mods manually is a bit, lets say bad for lazy people!

Also minor change to profile view, making the activated mods list scrollable (sorry for not putting this in its own branch.).