### PR TITLE
Fix page and mods count

### DIFF
--- a/src/renderer/pages/Portal.vue
+++ b/src/renderer/pages/Portal.vue
@@ -28,7 +28,13 @@
           </div>
 
           <div class="menu-section">
-            <input type="search" placeholder="Search..." class="search-mods" @change="setOnlineQuery($event.target.value); $event.target.focus()" />
+            <input
+              @change="setOnlineQuery($event.target.value); $event.target.focus()"
+              type="search"
+              placeholder="Search..."
+              class="search-mods"
+            >
+
             <button
               @click="fetchOnlineMods(true)"
               class="btn"

--- a/src/renderer/pages/Portal.vue
+++ b/src/renderer/pages/Portal.vue
@@ -29,7 +29,7 @@
 
           <div class="menu-section">
             <input
-              @change="setOnlineQuery($event.target.value); $event.target.focus()"
+              @search="setOnlineQuery($event.target.value);"
               type="search"
               placeholder="Search..."
               class="search-mods"

--- a/src/renderer/pages/Portal.vue
+++ b/src/renderer/pages/Portal.vue
@@ -54,7 +54,7 @@
 
         <OnlineModsList />
         <div class="menu">
-          <span class="menu-label">Results: {{ numMods }}</span>
+          <span class="menu-label">Results: {{ onlineModsCount }}</span>
           <span class="menu-label">Page {{ onlineModsPage + 1 }} of {{ maxPageOnlineMods + 1 }}</span>
           <div>
             <button
@@ -109,7 +109,6 @@ export default {
   },
   computed: {
     ...mapState({
-      numMods: state => (state.onlineMods && state.onlineMods.length) || 0,
       onlineModCategories: state => state.onlineModCategories,
       onlineModSorts: state => state.onlineModSorts,
       onlineModsPage: state => state.onlineModsPage,
@@ -118,7 +117,7 @@ export default {
       username: state => state.username,
       onlineQuery: state => state.onlineQuery,
     }),
-    ...mapGetters(['maxPageOnlineMods']),
+    ...mapGetters(['maxPageOnlineMods', 'onlineModsCount']),
   },
   created () {
     this.fetchOnlineMods()

--- a/src/renderer/store/getters.js
+++ b/src/renderer/store/getters.js
@@ -62,6 +62,10 @@ export const currentlyDisplayedOnlineMods = (state, getters) => {
   return getters.onlineMods.slice(startIndex, startIndex + onlineModsItemPerPage)
 }
 
+export const onlineModsCount = (state, getters) => {
+  return getters.onlineMods.length
+}
+
 export const maxPageOnlineMods = (state, getters) => {
   if (!state.onlineMods || !state.onlineMods.length === 0) return 0
 

--- a/src/renderer/store/getters.js
+++ b/src/renderer/store/getters.js
@@ -16,7 +16,7 @@ export const search = (state, getters) => (query, mods) => {
   return mods.filter(mod => mod.title.toLowerCase().search(query.toLowerCase()) > -1)
 }
 
-export const currentlyDisplayedOnlineMods = (state, getters) => {
+export const onlineMods = (state, getters) => {
   if (!state.onlineMods || !state.onlineMods.length === 0) return []
 
   let mods = state.onlineModsCurrentFilter === 'all'
@@ -27,8 +27,6 @@ export const currentlyDisplayedOnlineMods = (state, getters) => {
     ? mods
     : getters.search(state.onlineQuery, mods)
 
-  const { onlineModsItemPerPage, onlineModsPage } = state
-  const startIndex = onlineModsPage * onlineModsItemPerPage
   return mods
     .concat()
     .sort((a, b) => {
@@ -53,7 +51,15 @@ export const currentlyDisplayedOnlineMods = (state, getters) => {
         return 0
       }
     })
-    .slice(startIndex, startIndex + onlineModsItemPerPage)
+}
+
+export const currentlyDisplayedOnlineMods = (state, getters) => {
+  if (!state.onlineMods || !state.onlineMods.length === 0) return []
+
+  const { onlineModsItemPerPage, onlineModsPage } = state
+  const startIndex = onlineModsPage * onlineModsItemPerPage
+
+  getters.onlineMods.slice(startIndex, startIndex + onlineModsItemPerPage)
 }
 
 export const maxPageOnlineMods = (state, getters) => {

--- a/src/renderer/store/getters.js
+++ b/src/renderer/store/getters.js
@@ -59,7 +59,7 @@ export const currentlyDisplayedOnlineMods = (state, getters) => {
   const { onlineModsItemPerPage, onlineModsPage } = state
   const startIndex = onlineModsPage * onlineModsItemPerPage
 
-  getters.onlineMods.slice(startIndex, startIndex + onlineModsItemPerPage)
+  return getters.onlineMods.slice(startIndex, startIndex + onlineModsItemPerPage)
 }
 
 export const maxPageOnlineMods = (state, getters) => {

--- a/src/renderer/store/getters.js
+++ b/src/renderer/store/getters.js
@@ -69,7 +69,7 @@ export const onlineModsCount = (state, getters) => {
 export const maxPageOnlineMods = (state, getters) => {
   if (!state.onlineMods || !state.onlineMods.length === 0) return 0
 
-  return Math.floor(getters.onlineMods.length / state.onlineModsItemPerPage) - 1
+  return Math.floor(getters.onlineModsCount / state.onlineModsItemPerPage) - 1
 }
 
 export const isModDownloaded = (state) => (name) => {

--- a/src/renderer/store/getters.js
+++ b/src/renderer/store/getters.js
@@ -65,19 +65,7 @@ export const currentlyDisplayedOnlineMods = (state, getters) => {
 export const maxPageOnlineMods = (state, getters) => {
   if (!state.onlineMods || !state.onlineMods.length === 0) return 0
 
-  let count = state.onlineModsCurrentFilter === 'all'
-    ? state.onlineMods.length
-    : state.onlineMods.filter(mod => mod.category === state.onlineModsCurrentFilter).length
-
-  const mods = state.onlineModsCurrentFilter === 'all'
-    ? state.onlineMods
-    : state.onlineMods.filter(mod => mod.category === state.onlineModsCurrentFilter)
-
-  count = state.onlineQuery === ''
-    ? count
-    : getters.search(state.onlineQuery, mods).length
-
-  return Math.floor(count / state.onlineModsItemPerPage) - 1
+  return Math.floor(getters.onlineMods.length / state.onlineModsItemPerPage) - 1
 }
 
 export const isModDownloaded = (state) => (name) => {


### PR DESCRIPTION
In the commit 92d8bdd32c41923dbb8ff1bd70a31b5da133fcbc I have told that we should find a way around the hacky way I have fixed that. This pull request attacks that issue, but also the total mods count is now correctly displayed.

Also have fixed the search event, it now will correctly listen to the clear button clicked.
Also cleared linting warnings
These last two commits are in here since I didn't found it necessary to create a separate branch for it. 