### PR TITLE
Rework installed mods

### DIFF
--- a/src/main/lib/mod_manager.js
+++ b/src/main/lib/mod_manager.js
@@ -75,7 +75,7 @@ export default class ModManager {
     const mod = store.get('mods.installed', []).find(m => m.name === name)
 
     if (mod) {
-      const filePath = path.join(store.get('paths.mods'), `${mod.name}_${mod.version}.zip`)
+      const filePath = path.join(store.get('paths.mods'), `${mod.name}.zip`)
       await promisify(fs.unlink)(filePath)
 
       store.set('mods.installed', store.get('mods.installed').filter(m => m.name !== mod.name))

--- a/src/main/lib/mod_manager.js
+++ b/src/main/lib/mod_manager.js
@@ -26,7 +26,9 @@ export default class ModManager {
       const buffer = await promisify(fs.readFile)(path.join(modsPath, mod))
       const zip = await jsZip.loadAsync(buffer)
       const modData = await zip.file(/info\.json/)[0].async('text')
-      return JSON.parse(modData)
+      const data = JSON.parse(modData)
+      data.name = data.name + '_' + data.version
+      return data
     })))
 
     store.set('mods.installed', installedMods)

--- a/src/main/lib/mod_manager.js
+++ b/src/main/lib/mod_manager.js
@@ -26,9 +26,7 @@ export default class ModManager {
       const buffer = await promisify(fs.readFile)(path.join(modsPath, mod))
       const zip = await jsZip.loadAsync(buffer)
       const modData = await zip.file(/info\.json/)[0].async('text')
-      const data = JSON.parse(modData)
-      data.name = data.name + '_' + data.version
-      return data
+      return JSON.parse(modData)
     })))
 
     store.set('mods.installed', installedMods)

--- a/src/main/lib/mod_manager.js
+++ b/src/main/lib/mod_manager.js
@@ -73,7 +73,7 @@ export default class ModManager {
     const mod = store.get('mods.installed', []).find(m => m.name === name)
 
     if (mod) {
-      const filePath = path.join(store.get('paths.mods'), `${mod.name}.zip`)
+      const filePath = path.join(store.get('paths.mods'), `${mod.name}_${mod.version}.zip`)
       await promisify(fs.unlink)(filePath)
 
       store.set('mods.installed', store.get('mods.installed').filter(m => m.name !== mod.name))

--- a/src/renderer/components/InstalledModsList.vue
+++ b/src/renderer/components/InstalledModsList.vue
@@ -11,6 +11,7 @@
         <tr>
           <th class="cell-check" />
           <th>Name</th>
+          <th>Version</th>
         </tr>
       </thead>
       <tbody>
@@ -29,6 +30,9 @@
           </td>
           <td @click="selectInstalledMod(mod.name)">
             {{ mod.title }}
+          </td>
+          <td @click="selectInstalledMod(mod.name)">
+            {{ mod.version }}
           </td>
         </tr>
       </tbody>

--- a/src/renderer/components/InstalledModsList.vue
+++ b/src/renderer/components/InstalledModsList.vue
@@ -28,7 +28,7 @@
             </button>
           </td>
           <td @click="selectInstalledMod(mod.name)">
-            {{ mod.name }}
+            {{ mod.title }}
           </td>
         </tr>
       </tbody>

--- a/src/renderer/components/ProfileViewPanel.vue
+++ b/src/renderer/components/ProfileViewPanel.vue
@@ -63,7 +63,7 @@
             </button>
           </td>
           <td @click="selectInstalledMod(mod.name)">
-            {{ mod.name }}
+            {{ mod.title }}
           </td>
           <td>{{ mod.version }}</td>
         </tr>


### PR DESCRIPTION
Optimized the profile page;

* Made sure that only a single mod is selectable in the "available mods" sections
* Instead of displaying the mods name, it shows now the title both in the profile enabled mods and the available mods list
* Display the version in the available mods list
* Fixed deleting mods that had more then one version installed