### PR TITLE
Add app options and  more interactivity with existing options

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "webpack-hot-middleware": "^2.25.0"
   },
   "dependencies": {
-    "electron-store": "^4.0.0",
+    "electron-store": "^5.1.1",
     "jszip": "^3.2.2",
     "node-fetch": "^2.6.0",
     "vue": "^2.6.10",

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -165,6 +165,10 @@ const addClientEventListeners = async () => {
     const saves = await saveManager.retrieveFactorioSaves()
     event.reply('FACTORIO_SAVES', saves)
   })
+
+  ipcMain.on('UPDATE_OPTION', (event, { name, value }) => {
+    store.set(`options.${name}`, value)
+  })
 }
 
 const initializeApp = async () => {

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -92,6 +92,10 @@ const addClientEventListeners = async () => {
     mainWindow.webContents.send('APP_OPTIONS', newValue)
   })
 
+  store.onDidChange('paths', (newValue) => {
+    mainWindow.webContents.send('FACTORIO_PATHS', newValue)
+  })
+
   if (isDevMode) {
     // Normally won't need to call these events
     // but during development if renderer code is reloaded then the app won't send info again and that's annoying
@@ -114,6 +118,21 @@ const addClientEventListeners = async () => {
 
     ipcMain.on('REQUEST_OPTIONS', (event) => {
       event.reply('APP_OPTIONS', store.get('options'))
+    })
+
+    ipcMain.on('REQUEST_FACTORIO_PATHS', (event) => {
+      event.reply('FACTORIO_PATHS', store.get('paths'))
+    })
+
+    ipcMain.on('PROMPT_NEW_FACTORIO_PATH', async (event, pathName) => {
+      let path
+
+      if (pathName === 'factorio') path = await appManager.findFactorioPath(mainWindow, true)
+      if (pathName === 'mods') path = await appManager.findFactorioModPath(mainWindow, true)
+      if (pathName === 'saves') path = await appManager.findFactorioSavesPath(mainWindow, true)
+      if (pathName === 'playerData') path = await appManager.findFactorioPlayerData(mainWindow, true)
+
+      if (path) store.set(`paths.${pathName}`, path)
     })
   }
 
@@ -169,6 +188,10 @@ const addClientEventListeners = async () => {
   ipcMain.on('UPDATE_OPTION', (event, { name, value }) => {
     store.set(`options.${name}`, value)
   })
+
+  ipcMain.on('UPDATE_FACTORIO_PATH', (event, { name, value }) => {
+    store.set(`paths.${name}`, value)
+  })
 }
 
 const initializeApp = async () => {
@@ -196,6 +219,7 @@ const initializeApp = async () => {
   mainWindow.webContents.send('PROFILES_LIST', store.get('profiles.list'))
   mainWindow.webContents.send('PROFILES_ACTIVE', store.get('profiles.active'))
   mainWindow.webContents.send('APP_OPTIONS', store.get('options'))
+  mainWindow.webContents.send('FACTORIO_PATHS', store.get('paths'))
 }
 
 const createWindow = () => {

--- a/src/main/lib/app_manager.js
+++ b/src/main/lib/app_manager.js
@@ -439,7 +439,9 @@ export default class AppManager {
       log.error(`${error.code} ${error.message}`, { namespace: 'main.app_manager.startFactorio' })
     }
 
-    this.closeApp()
+    if (store.get('options.closeOnStartup')) {
+      this.closeApp()
+    }
 
     log.debug(`Exiting function`, { namespace: 'main.app_manager.startFactorio' })
   }

--- a/src/main/lib/app_manager.js
+++ b/src/main/lib/app_manager.js
@@ -83,45 +83,47 @@ export default class AppManager {
     log.debug('Leaving function', { namespace: 'main.app_manager.configureEventListeners' })
   }
 
-  async findFactorioPath (mainWindow) {
+  async findFactorioPath (mainWindow, forceManual = false) {
     log.debug('Entering function', { namespace: 'main.app_manager.findFactorioPath' })
 
-    // Compile a list of what I guess are common paths
-    const paths = []
-    switch (os.platform()) {
-      case 'win32':
-        paths.push(path.join('C:\\', 'Program Files', 'Factorio', 'bin', 'Win32', 'factorio.exe'))
-        paths.push(path.join('C:\\', 'Program Files', 'Factorio', 'bin', 'x64', 'factorio.exe'))
-        paths.push(path.join('C:\\', 'Program Files (x86)', 'Factorio', 'bin', 'Win32', 'factorio.exe'))
-        paths.push(path.join('C:\\', 'Program Files (x86)', 'Factorio', 'bin', 'x64', 'factorio.exe'))
-        paths.push(path.join('C:\\', 'Program Files', 'Steam', 'SteamApps', 'common', 'Factorio', 'bin', 'Win32', 'factorio.exe'))
-        paths.push(path.join('C:\\', 'Program Files', 'Steam', 'SteamApps', 'common', 'Factorio', 'bin', 'x64', 'factorio.exe'))
-        paths.push(path.join('C:\\', 'Program Files (x86)', 'Steam', 'SteamApps', 'common', 'Factorio', 'bin', 'Win32', 'factorio.exe'))
-        paths.push(path.join('C:\\', 'Program Files (x86)', 'Steam', 'SteamApps', 'common', 'Factorio', 'bin', 'x64', 'factorio.exe'))
-        break
-      case 'linux':
-        paths.push(path.join(app.getPath('home'), '.steam/steam/steamapps/common/Factorio/bin/x64/factorio'))
-        paths.push(path.join(app.getPath('home'), '.steam/steam/steamapps/common/Factorio/bin/i386/factorio'))
-        paths.push(path.join(app.getPath('home'), '.factorio', 'bin', 'x64', 'factorio'))
-        paths.push(path.join(app.getPath('home'), 'factorio', 'bin', 'i386', 'factorio'))
-        break
-      case 'darwin':
-        paths.push(path.join(app.getPath('home'), 'Library', 'Application Support', 'Steam', 'steamapps', 'common', 'Factorio', 'factorio.app', 'Contents', 'MacOS', 'factorio'))
-        break
-    }
+    if (!forceManual) {
+      // Compile a list of what I guess are common paths
+      const paths = []
+      switch (os.platform()) {
+        case 'win32':
+          paths.push(path.join('C:\\', 'Program Files', 'Factorio', 'bin', 'Win32', 'factorio.exe'))
+          paths.push(path.join('C:\\', 'Program Files', 'Factorio', 'bin', 'x64', 'factorio.exe'))
+          paths.push(path.join('C:\\', 'Program Files (x86)', 'Factorio', 'bin', 'Win32', 'factorio.exe'))
+          paths.push(path.join('C:\\', 'Program Files (x86)', 'Factorio', 'bin', 'x64', 'factorio.exe'))
+          paths.push(path.join('C:\\', 'Program Files', 'Steam', 'SteamApps', 'common', 'Factorio', 'bin', 'Win32', 'factorio.exe'))
+          paths.push(path.join('C:\\', 'Program Files', 'Steam', 'SteamApps', 'common', 'Factorio', 'bin', 'x64', 'factorio.exe'))
+          paths.push(path.join('C:\\', 'Program Files (x86)', 'Steam', 'SteamApps', 'common', 'Factorio', 'bin', 'Win32', 'factorio.exe'))
+          paths.push(path.join('C:\\', 'Program Files (x86)', 'Steam', 'SteamApps', 'common', 'Factorio', 'bin', 'x64', 'factorio.exe'))
+          break
+        case 'linux':
+          paths.push(path.join(app.getPath('home'), '.steam/steam/steamapps/common/Factorio/bin/x64/factorio'))
+          paths.push(path.join(app.getPath('home'), '.steam/steam/steamapps/common/Factorio/bin/i386/factorio'))
+          paths.push(path.join(app.getPath('home'), '.factorio', 'bin', 'x64', 'factorio'))
+          paths.push(path.join(app.getPath('home'), 'factorio', 'bin', 'i386', 'factorio'))
+          break
+        case 'darwin':
+          paths.push(path.join(app.getPath('home'), 'Library', 'Application Support', 'Steam', 'steamapps', 'common', 'Factorio', 'factorio.app', 'Contents', 'MacOS', 'factorio'))
+          break
+      }
 
-    log.debug('Starting loop to automatically find paths.factorio', { namespace: 'main.app_manager.findFactorioPath' })
-    for (let i = 0, length = paths.length; i < length; i++) {
-      try {
-        if (fs.existsSync(paths[i])) {
-          log.info('paths.factorio found with automatic search', { namespace: 'main.app_manager.findFactorioPath' })
-          log.debug(`Exiting function, retval: ${paths[i]}`, { namespace: 'main.app_manager.findFactorioPath' })
-          return paths[i]
-        }
-      } catch (error) {
-        if (error.code !== 'ENOENT') {
-          log.error(`${error.code} ${error.message}`, { namespace: 'main.app_manager.findFactorioPath' })
-          return
+      log.debug('Starting loop to automatically find paths.factorio', { namespace: 'main.app_manager.findFactorioPath' })
+      for (let i = 0, length = paths.length; i < length; i++) {
+        try {
+          if (fs.existsSync(paths[i])) {
+            log.info('paths.factorio found with automatic search', { namespace: 'main.app_manager.findFactorioPath' })
+            log.debug(`Exiting function, retval: ${paths[i]}`, { namespace: 'main.app_manager.findFactorioPath' })
+            return paths[i]
+          }
+        } catch (error) {
+          if (error.code !== 'ENOENT') {
+            log.error(`${error.code} ${error.message}`, { namespace: 'main.app_manager.findFactorioPath' })
+            return
+          }
         }
       }
     }
@@ -156,37 +158,39 @@ export default class AppManager {
     log.debug(`Exiting function`, { namespace: 'main.app_manager.findFactorioPath' })
   }
 
-  async findFactorioModPath (mainWindow) {
+  async findFactorioModPath (mainWindow, forceManual = false) {
     log.debug('Entering function', { namespace: 'main.app_manager.findFactorioModPath' })
 
-    // Compile a list of what I guess are common paths
-    const paths = []
-    switch (os.platform()) {
-      case 'win32':
-        paths.push(path.join(app.getPath('appData'), 'Factorio', 'mods', 'mod-list.json'))
-        paths.push(path.join('C:\\', 'Program Files', 'Factorio', 'mods', 'mod-list.json'))
-        paths.push(path.join('C:\\', 'Program Files (x86)', 'Factorio', 'mods', 'mod-list.json'))
-        break
-      case 'linux':
-        paths.push(path.join(app.getPath('home'), '.factorio', 'mods', 'mod-list.json'))
-        paths.push(path.join(app.getPath('home'), 'factorio', 'mods', 'mod-list.json'))
-        break
-      case 'darwin':
-        paths.push(path.join(app.getPath('home'), 'Library', 'Application Support', 'factorio', 'mods', 'mod-list.json'))
-        break
-    }
+    if (!forceManual) {
+      // Compile a list of what I guess are common paths
+      const paths = []
+      switch (os.platform()) {
+        case 'win32':
+          paths.push(path.join(app.getPath('appData'), 'Factorio', 'mods', 'mod-list.json'))
+          paths.push(path.join('C:\\', 'Program Files', 'Factorio', 'mods', 'mod-list.json'))
+          paths.push(path.join('C:\\', 'Program Files (x86)', 'Factorio', 'mods', 'mod-list.json'))
+          break
+        case 'linux':
+          paths.push(path.join(app.getPath('home'), '.factorio', 'mods', 'mod-list.json'))
+          paths.push(path.join(app.getPath('home'), 'factorio', 'mods', 'mod-list.json'))
+          break
+        case 'darwin':
+          paths.push(path.join(app.getPath('home'), 'Library', 'Application Support', 'factorio', 'mods', 'mod-list.json'))
+          break
+      }
 
-    for (let i = 0, length = paths.length; i < length; i++) {
-      try {
-        if (fs.existsSync(paths[i])) {
-          log.info('paths.mods found with automatic search', { namespace: 'main.app_manager.findFactorioModPath' })
-          log.debug(`Exiting function, retval: ${path.join(paths[i], '..')}`, { namespace: 'main.app_manager.findFactorioModPath' })
-          return path.join(paths[i], '..')
-        }
-      } catch (error) {
-        if (error.code !== 'ENOENT') {
-          log.error(`${error.code} ${error.message}`, { namespace: 'main.app_manager.findFactorioModPath' })
-          return
+      for (let i = 0, length = paths.length; i < length; i++) {
+        try {
+          if (fs.existsSync(paths[i])) {
+            log.info('paths.mods found with automatic search', { namespace: 'main.app_manager.findFactorioModPath' })
+            log.debug(`Exiting function, retval: ${path.join(paths[i], '..')}`, { namespace: 'main.app_manager.findFactorioModPath' })
+            return path.join(paths[i], '..')
+          }
+        } catch (error) {
+          if (error.code !== 'ENOENT') {
+            log.error(`${error.code} ${error.message}`, { namespace: 'main.app_manager.findFactorioModPath' })
+            return
+          }
         }
       }
     }
@@ -211,43 +215,45 @@ export default class AppManager {
     log.debug(`Exiting function`, { namespace: 'main.app_manager.findFactorioModPath' })
   }
 
-  async findFactorioSavesPath (mainWindow) {
+  async findFactorioSavesPath (mainWindow, forceManual = false) {
     log.debug('Entering function', { namespace: 'main.app_manager.findFactorioSavesPath' })
 
-    // Compile a list of what I guess are common paths
-    const paths = []
-    switch (os.platform()) {
-      case 'win32':
-        paths.push(
-          path.join(app.getPath('appData'), 'Factorio/saves'),
-          path.join('C:\\', 'Program Files/Factorio/saves'),
-          path.join('C:\\', 'Program Files (x86)/Factorio/saves'),
-        )
-        break
-      case 'linux':
-        paths.push(
-          path.join(app.getPath('home'), '.factorio/saves'),
-          path.join(app.getPath('home'), 'factorio/saves'),
-        )
-        break
-      case 'darwin':
-        paths.push(
-          path.join(app.getPath('home'), 'Library/Application Support/factorio/saves'),
-        )
-        break
-    }
+    if (!forceManual) {
+      // Compile a list of what I guess are common paths
+      const paths = []
+      switch (os.platform()) {
+        case 'win32':
+          paths.push(
+            path.join(app.getPath('appData'), 'Factorio/saves'),
+            path.join('C:\\', 'Program Files/Factorio/saves'),
+            path.join('C:\\', 'Program Files (x86)/Factorio/saves'),
+          )
+          break
+        case 'linux':
+          paths.push(
+            path.join(app.getPath('home'), '.factorio/saves'),
+            path.join(app.getPath('home'), 'factorio/saves'),
+          )
+          break
+        case 'darwin':
+          paths.push(
+            path.join(app.getPath('home'), 'Library/Application Support/factorio/saves'),
+          )
+          break
+      }
 
-    for (let i = 0, length = paths.length; i < length; i++) {
-      try {
-        if (fs.existsSync(paths[i])) {
-          log.info('paths.saves found with automatic search', { namespace: 'main.app_manager.findFactorioSavesPath' })
-          log.debug(`Exiting function, retval: ${path.join(paths[i])}`, { namespace: 'main.app_manager.findFactorioSavesPath' })
-          return path.join(paths[i])
-        }
-      } catch (error) {
-        if (error.code !== 'ENOENT') {
-          log.error(`${error.code} ${error.message}`, { namespace: 'main.app_manager.findFactorioSavesPath' })
-          return
+      for (let i = 0, length = paths.length; i < length; i++) {
+        try {
+          if (fs.existsSync(paths[i])) {
+            log.info('paths.saves found with automatic search', { namespace: 'main.app_manager.findFactorioSavesPath' })
+            log.debug(`Exiting function, retval: ${path.join(paths[i])}`, { namespace: 'main.app_manager.findFactorioSavesPath' })
+            return path.join(paths[i])
+          }
+        } catch (error) {
+          if (error.code !== 'ENOENT') {
+            log.error(`${error.code} ${error.message}`, { namespace: 'main.app_manager.findFactorioSavesPath' })
+            return
+          }
         }
       }
     }
@@ -272,36 +278,38 @@ export default class AppManager {
     log.debug(`Exiting function`, { namespace: 'main.app_manager.findFactorioSavesPath' })
   }
 
-  async findFactorioPlayerData (mainWindow) {
+  async findFactorioPlayerData (mainWindow, forceManual = false) {
     log.debug(`Entering function`, { namespace: 'main.app_manager.findFactorioPlayerData' })
 
-    // Compile a list of what I guess are common paths
-    const paths = []
-    switch (os.platform()) {
-      case 'win32':
-        paths.push(path.join(app.getPath('appData'), 'Factorio', 'player-data.json'))
-        paths.push(path.join(app.getPath('appData'), 'Factorio', 'config', 'player-data.json'))
-        break
-      case 'linux':
-        paths.push(path.join(app.getPath('home'), '.factorio', 'player-data.json'))
-        paths.push(path.join(app.getPath('home'), 'factorio', 'player-data.json'))
-        break
-      case 'darwin':
-        paths.push(path.join(app.getPath('home'), 'Library', 'Application Support', 'factorio', 'player-data.json'))
-        break
-    }
+    if (!forceManual) {
+      // Compile a list of what I guess are common paths
+      const paths = []
+      switch (os.platform()) {
+        case 'win32':
+          paths.push(path.join(app.getPath('appData'), 'Factorio', 'player-data.json'))
+          paths.push(path.join(app.getPath('appData'), 'Factorio', 'config', 'player-data.json'))
+          break
+        case 'linux':
+          paths.push(path.join(app.getPath('home'), '.factorio', 'player-data.json'))
+          paths.push(path.join(app.getPath('home'), 'factorio', 'player-data.json'))
+          break
+        case 'darwin':
+          paths.push(path.join(app.getPath('home'), 'Library', 'Application Support', 'factorio', 'player-data.json'))
+          break
+      }
 
-    for (let i = 0, length = paths.length; i < length; i++) {
-      try {
-        if (fs.existsSync(paths[i])) {
-          log.info('paths.playerData found with automatic search', { namespace: 'main.app_manager.findFactorioPlayerData' })
-          log.debug(`Exiting function, retval: ${paths[i]}`, { namespace: 'main.app_manager.findFactorioPlayerData' })
-          return paths[i]
-        }
-      } catch (error) {
-        if (error.code !== 'ENOENT') {
-          log.error(`${error.code} ${error.message}`, { namespace: 'main.app_manager.findFactorioPlayerData' })
-          return
+      for (let i = 0, length = paths.length; i < length; i++) {
+        try {
+          if (fs.existsSync(paths[i])) {
+            log.info('paths.playerData found with automatic search', { namespace: 'main.app_manager.findFactorioPlayerData' })
+            log.debug(`Exiting function, retval: ${paths[i]}`, { namespace: 'main.app_manager.findFactorioPlayerData' })
+            return paths[i]
+          }
+        } catch (error) {
+          if (error.code !== 'ENOENT') {
+            log.error(`${error.code} ${error.message}`, { namespace: 'main.app_manager.findFactorioPlayerData' })
+            return
+          }
         }
       }
     }

--- a/src/main/lib/mod_manager.js
+++ b/src/main/lib/mod_manager.js
@@ -4,7 +4,10 @@ import { promisify } from 'util'
 import jsZip from 'jszip'
 import fetch from 'node-fetch'
 
-import store from '@lib/store'
+import {
+  config as store,
+  onlineModsCache,
+} from '@lib/store'
 import log from './logger'
 
 import { parseModDependencies } from '@shared/util'
@@ -110,8 +113,8 @@ export default class ModManager {
     log.debug('Entered function', { namespace: 'main.mod_manager.fetchOnlineMods' })
 
     if (!force) {
-      const onlineCount = store.get('mods.onlineCount')
-      const onlineLastFetch = store.get('mods.onlineLastFetch')
+      const onlineCount = onlineModsCache.get('count')
+      const onlineLastFetch = onlineModsCache.get('lastFetch')
       if (onlineCount && onlineLastFetch) {
         const now = Date.now()
         if (now - onlineLastFetch <= 86400000) {
@@ -128,10 +131,10 @@ export default class ModManager {
 
     try {
       const data = await (await fetch(apiUrl)).json()
-      store.set({
-        'mods.online': data.results,
-        'mods.onlineCount': data.results.length,
-        'mods.onlineLastFetch': Date.now(),
+      onlineModsCache.set({
+        mods: data.results,
+        count: data.results.length,
+        lastFetch: Date.now(),
       })
       log.info(`Successfully retrieved list of online mods. Count: ${data.results.length}`, { namespace: 'main.mod_manager.fetchOnlineMods' })
     } catch (error) {
@@ -145,13 +148,13 @@ export default class ModManager {
   async fetchOnlineModDetailedInfo (modName, force = false) {
     log.debug('Entered function', { namespace: 'main.mod_manager.fetchOnlineModDetailedInfo' })
 
-    const index = store.get('mods.online', []).findIndex(m => m.name === modName)
+    const index = onlineModsCache.get('mods', []).findIndex(m => m.name === modName)
     if (index === -1) {
       log.info(`Attempted to retrieve detailed info for online mod '${modName}' but online mods have not been retrieved yet. Skipping.`, { namespace: 'main.mod_manager.fetchOnlineModDetailedInfo' })
       return
     }
 
-    const onlineMod = store.get('mods.online')[index]
+    const onlineMod = onlineModsCache.get('mods')[index]
     if (!force) {
       // These two seem to only be provided when getting the /full route, so it's a good check
       if (onlineMod.changelog || onlineMod.github_path) {
@@ -162,12 +165,12 @@ export default class ModManager {
       log.info(`Force refresh of online mod '${modName}' has been recieved`, { namespace: 'main.mod_manager.fetchOnlineModDetailedInfo' })
     }
 
-    const mods = store.get('mods.online')
+    const mods = onlineModsCache.get('mods')
     try {
       const apiUrl = `https://mods.factorio.com/api/mods/${modName}/full`
 
       mods[index] = await (await fetch(apiUrl)).json()
-      store.set({ 'mods.online': mods })
+      onlineModsCache.set({ mods: mods })
 
       log.info(`Detailed info successfully retrieved for '${modName}' and saved in the app`, { namespace: 'main.mod_manager.fetchOnlineModDetailedInfo' })
     } catch (error) {

--- a/src/main/lib/mod_manager.js
+++ b/src/main/lib/mod_manager.js
@@ -115,9 +115,11 @@ export default class ModManager {
     if (!force) {
       const onlineCount = onlineModsCache.get('count')
       const onlineLastFetch = onlineModsCache.get('lastFetch')
+      const pollingInterval = store.get('options.onlinePollingInterval')
+
       if (onlineCount && onlineLastFetch) {
         const now = Date.now()
-        if (now - onlineLastFetch <= 86400000) {
+        if (now - onlineLastFetch <= (pollingInterval * 86400000)) {
           log.info('Skipping refresh of online mod list, as last fetch time was too recent.', { namespace: 'main.mod_manager.fetchOnlineMods' })
           return
         }

--- a/src/main/lib/store.js
+++ b/src/main/lib/store.js
@@ -1,8 +1,32 @@
 import Store from 'electron-store'
-import models from '@shared/models'
 
-const storeFile = new Store({
-  schema: models,
+import * as migrations from '@shared/migrations'
+import schema from '@shared/models'
+
+const configSchema = {
+  mods: schema.mods,
+  options: schema.options,
+  profiles: schema.profiles,
+  paths: schema.paths,
+  player: schema.player,
+  window: schema.window,
+}
+
+export const config = new Store({
+  cwd: 'data',
+  serialize: value => JSON.stringify(value, null, 2),
+
+  migrations: migrations.config,
+  schema: configSchema,
 })
 
-export default storeFile
+export const onlineModsCache = new Store({
+  cwd: 'data',
+  name: 'onlineModsCache',
+  serialize: value => JSON.stringify(value, null, 0),
+
+  migrations: migrations.onlineModsCache,
+  schema: schema.onlineModsCache,
+})
+
+export default config

--- a/src/renderer/components/Navbar.vue
+++ b/src/renderer/components/Navbar.vue
@@ -111,6 +111,7 @@ nav.navbar {
     border-top-right-radius: 5px;
 
     user-select: none;
+    height: auto;
 
     &:hover {
       border-color: $highlight-color;

--- a/src/renderer/components/Navbar.vue
+++ b/src/renderer/components/Navbar.vue
@@ -20,6 +20,12 @@
         Mod Portal
       </router-link>
       <router-link
+        to="/options"
+        class="btn"
+      >
+        Options
+      </router-link>
+      <router-link
         to="/about"
         class="btn"
       >

--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -54,24 +54,28 @@ ipcRenderer.on('INSTALLED_MODS', (event, data) => {
   store.dispatch('selectInstalledMod', (store.state.selectedMod || { name: '' }).name)
 })
 
-ipcRenderer.on('ONLINE_MODS', (event, data) => {
-  store.commit('SET_ONLINE_MODS', { onlineMods: data })
+ipcRenderer.on('ONLINE_MODS', (event, onlineMods) => {
+  store.commit('SET_ONLINE_MODS', { onlineMods })
 })
 
-ipcRenderer.on('FACTORIO_SAVES', (event, data) => {
-  store.commit('SET_SAVES', { saves: data })
+ipcRenderer.on('FACTORIO_SAVES', (event, saves) => {
+  store.commit('SET_SAVES', { saves })
 })
 
-ipcRenderer.on('PROFILES_LIST', (event, data) => {
-  store.commit('SET_PROFILES', { profiles: data })
+ipcRenderer.on('PROFILES_LIST', (event, profiles) => {
+  store.commit('SET_PROFILES', { profiles })
 })
 
-ipcRenderer.on('PROFILES_ACTIVE', (event, data) => {
-  store.commit('SET_ACTIVE_PROFILE', { activeProfile: data })
+ipcRenderer.on('PROFILES_ACTIVE', (event, activeProfile) => {
+  store.commit('SET_ACTIVE_PROFILE', { activeProfile })
 })
 
-ipcRenderer.on('APP_OPTIONS', (event, data) => {
-  store.commit('UPDATE_OPTIONS', { options: data })
+ipcRenderer.on('APP_OPTIONS', (event, options) => {
+  store.commit('UPDATE_OPTIONS', { options })
+})
+
+ipcRenderer.on('FACTORIO_PATHS', (event, paths) => {
+  store.commit('UPDATE_FACTORIO_PATHS', { paths })
 })
 
 if (isDev) {
@@ -82,4 +86,5 @@ if (isDev) {
   ipcRenderer.send('REQUEST_ONLINE_MODS')
   ipcRenderer.send('REQUEST_PROFILES')
   ipcRenderer.send('REQUEST_OPTIONS')
+  ipcRenderer.send('REQUEST_FACTORIO_PATHS')
 }

--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -70,6 +70,10 @@ ipcRenderer.on('PROFILES_ACTIVE', (event, data) => {
   store.commit('SET_ACTIVE_PROFILE', { activeProfile: data })
 })
 
+ipcRenderer.on('OPTIONS', (event, data) => {
+  store.commit('UPDATE_OPTIONS', { options: data })
+})
+
 if (isDev) {
   // Normally won't need to call these events
   // but during development if renderer code is reloaded then the app won't send info again and that's annoying
@@ -77,4 +81,5 @@ if (isDev) {
   ipcRenderer.send('REQUEST_INSTALLED_MODS')
   ipcRenderer.send('REQUEST_ONLINE_MODS')
   ipcRenderer.send('REQUEST_PROFILES')
+  ipcRenderer.send('REQUEST_OPTIONS')
 }

--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -70,7 +70,8 @@ ipcRenderer.on('PROFILES_ACTIVE', (event, data) => {
   store.commit('SET_ACTIVE_PROFILE', { activeProfile: data })
 })
 
-ipcRenderer.on('OPTIONS', (event, data) => {
+ipcRenderer.on('APP_OPTIONS', (event, data) => {
+  console.log('got options', data)
   store.commit('UPDATE_OPTIONS', { options: data })
 })
 

--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -71,7 +71,6 @@ ipcRenderer.on('PROFILES_ACTIVE', (event, data) => {
 })
 
 ipcRenderer.on('APP_OPTIONS', (event, data) => {
-  console.log('got options', data)
   store.commit('UPDATE_OPTIONS', { options: data })
 })
 

--- a/src/renderer/pages/Options.vue
+++ b/src/renderer/pages/Options.vue
@@ -32,5 +32,25 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+.page-options {
+  padding: 10px 20px;
+}
 
+label {
+  display: flex;
+  flex-direction: column;
+  align-items: left;
+
+  input {
+    margin-top: 5px;
+    margin-bottom: 20px;
+    padding: 15px;
+    width: fit-content;
+
+    &[type="checkbox"] {
+      width: 20px;
+      height: 20px;
+    }
+  }
+}
 </style>

--- a/src/renderer/pages/Options.vue
+++ b/src/renderer/pages/Options.vue
@@ -1,26 +1,51 @@
 <template>
   <div class="page-options">
-    <label>
-      Close app when starting Factorio
-      <input
-        type="checkbox"
-        :checked="options.closeOnStartup"
-        @change="updateOption({ name: 'closeOnStartup', value: $event.target.checked })"
-      >
-    </label>
+    <form @submit.prevent>
+      <label>
+        Close app when starting Factorio
+        <input
+          type="checkbox"
+          :checked="options.closeOnStartup"
+          @change="updateOption({ name: 'closeOnStartup', value: $event.target.checked })"
+        >
+      </label>
 
-    <label>
-      How often to poll the mod portal (in days) for all online mods
-      <input
-        type="number"
-        :value="options.onlinePollingInterval"
-        @change="updateOption({ name: 'onlinePollingInterval', value: $event.target.value })"
-      >
-    </label>
+      <label>
+        How often to poll the mod portal (in days) for all online mods
+        <input
+          type="number"
+          :value="options.onlinePollingInterval"
+          @change="updateOption({ name: 'onlinePollingInterval', value: parseInt($event.target.value, 10) })"
+        >
+      </label>
+    </form>
+
+    <div class="paths-container">
+      <button @click="openFolder(userDataPath)">
+        Open Folder
+      </button>
+      <label>AppData Directory</label>
+      <span>{{ userDataPath }}</span>
+
+      <button @click="openFolder(logsPath)">
+        Open Folder
+      </button>
+      <label>Logs Directory</label>
+      <span>{{ logsPath }}</span>
+
+      <button @click="openFolder(configPath)">
+        Open Folder
+      </button>
+      <label>Config Directory</label>
+      <span>{{ configPath }}</span>
+    </div>
   </div>
 </template>
 
 <script>
+import { join } from 'path'
+import { remote } from 'electron'
+
 import { mapActions, mapState } from 'vuex'
 
 export default {
@@ -29,9 +54,21 @@ export default {
     ...mapState({
       options: 'options',
     }),
+    userDataPath () {
+      return remote.app.getPath('userData')
+    },
+    logsPath () {
+      return join(this.userDataPath, 'logs')
+    },
+    configPath () {
+      return join(this.userDataPath, 'data')
+    },
   },
   methods: {
     ...mapActions(['updateOption']),
+    openFolder (path) {
+      remote.shell.openItem(path)
+    },
   },
 }
 </script>
@@ -41,10 +78,12 @@ export default {
   padding: 10px 20px;
 }
 
-label {
-  display: flex;
-  flex-direction: column;
-  align-items: left;
+form {
+  label {
+    display: flex;
+    flex-direction: column;
+    align-items: left;
+  }
 
   input {
     margin-top: 5px;
@@ -57,5 +96,14 @@ label {
       height: 20px;
     }
   }
+}
+
+.paths-container {
+  display: grid;
+  grid-template-columns: auto auto 1fr;
+  grid-template-rows: 1fr;
+
+  align-items: center;
+  grid-gap: 10px;
 }
 </style>

--- a/src/renderer/pages/Options.vue
+++ b/src/renderer/pages/Options.vue
@@ -1,0 +1,36 @@
+<template>
+  <div class="page-options">
+    <label>
+      Close app when starting Factorio
+      <input
+        v-model="options.closeOnStartup"
+        type="checkbox"
+      >
+    </label>
+
+    <label>
+      How often to poll the mod portal for all online mods
+      <input
+        v-model="options.onlinePollingInterval"
+        type="number"
+      >
+    </label>
+  </div>
+</template>
+
+<script>
+import { mapState } from 'vuex'
+
+export default {
+  name: 'PageOptions',
+  computed: {
+    ...mapState({
+      options: 'options',
+    }),
+  },
+}
+</script>
+
+<style lang="scss" scoped>
+
+</style>

--- a/src/renderer/pages/Options.vue
+++ b/src/renderer/pages/Options.vue
@@ -32,12 +32,27 @@
       </button>
       <label>Logs Directory</label>
       <span>{{ logsPath }}</span>
+      <span /><span />
+      <div>
+        <button @click="openFolder(logsPath + '/info-log.txt')">
+          Open Info Log
+        </button>
+        <button @click="openFolder(logsPath + '/error-log.txt')">
+          Open Error Log
+        </button>
+      </div>
 
       <button @click="openFolder(configPath)">
         Open Folder
       </button>
       <label>Config Directory</label>
       <span>{{ configPath }}</span>
+      <span /><span />
+      <div>
+        <button @click="openFolder(configPath + '/config.json')">
+          Open Configuration File
+        </button>
+      </div>
     </div>
   </div>
 </template>

--- a/src/renderer/pages/Options.vue
+++ b/src/renderer/pages/Options.vue
@@ -10,7 +10,7 @@
     </label>
 
     <label>
-      How often to poll the mod portal for all online mods
+      How often to poll the mod portal (in days) for all online mods
       <input
         type="number"
         :value="options.onlinePollingInterval"

--- a/src/renderer/pages/Options.vue
+++ b/src/renderer/pages/Options.vue
@@ -3,23 +3,25 @@
     <label>
       Close app when starting Factorio
       <input
-        v-model="options.closeOnStartup"
         type="checkbox"
+        :checked="options.closeOnStartup"
+        @change="updateOption({ name: 'closeOnStartup', value: $event.target.checked })"
       >
     </label>
 
     <label>
       How often to poll the mod portal for all online mods
       <input
-        v-model="options.onlinePollingInterval"
         type="number"
+        :value="options.onlinePollingInterval"
+        @change="updateOption({ name: 'onlinePollingInterval', value: $event.target.value })"
       >
     </label>
   </div>
 </template>
 
 <script>
-import { mapState } from 'vuex'
+import { mapActions, mapState } from 'vuex'
 
 export default {
   name: 'PageOptions',
@@ -27,6 +29,9 @@ export default {
     ...mapState({
       options: 'options',
     }),
+  },
+  methods: {
+    ...mapActions(['updateOption']),
   },
 }
 </script>

--- a/src/renderer/pages/Options.vue
+++ b/src/renderer/pages/Options.vue
@@ -13,12 +13,32 @@
       <label>
         How often to poll the mod portal (in days) for all online mods
         <input
-          type="number"
+          type="text"
           :value="options.onlinePollingInterval"
           @change="updateOption({ name: 'onlinePollingInterval', value: parseInt($event.target.value, 10) })"
         >
       </label>
+
+      <div
+        v-for="path of pathOptions"
+        :key="'path-' + path.variable"
+        class="input-group"
+      >
+        <label>{{ path.text }}</label>
+        <button
+          @click="promptNewFactorioPath(path.variable)"
+        >
+          Change
+        </button>
+        <input
+          type="text"
+          :value="paths[path.variable]"
+          disabled
+        >
+      </div>
     </form>
+
+    <hr>
 
     <div class="paths-container">
       <button @click="openFolder(userDataPath)">
@@ -65,9 +85,18 @@ import { mapActions, mapState } from 'vuex'
 
 export default {
   name: 'PageOptions',
+  data: () => ({
+    pathOptions: [
+      { text: 'Factorio Exe Path', variable: 'factorio' },
+      { text: 'Mods Folder Path', variable: 'mods' },
+      { text: 'PlayerData File Path', variable: 'playerData' },
+      { text: 'Saves Folder Path', variable: 'saves' },
+    ],
+  }),
   computed: {
     ...mapState({
       options: 'options',
+      paths: 'paths',
     }),
     userDataPath () {
       return remote.app.getPath('userData')
@@ -80,7 +109,7 @@ export default {
     },
   },
   methods: {
-    ...mapActions(['updateOption']),
+    ...mapActions(['promptNewFactorioPath', 'updateOption']),
     openFolder (path) {
       remote.shell.openItem(path)
     },
@@ -93,23 +122,25 @@ export default {
   padding: 10px 20px;
 }
 
-form {
-  label {
-    display: flex;
-    flex-direction: column;
-    align-items: left;
+label {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+}
+
+input {
+  margin-top: 5px;
+  margin-bottom: 20px;
+  padding: 15px;
+  width: fit-content;
+
+  &[type="checkbox"] {
+    width: 20px;
+    height: 20px;
   }
 
-  input {
-    margin-top: 5px;
-    margin-bottom: 20px;
-    padding: 15px;
-    width: fit-content;
-
-    &[type="checkbox"] {
-      width: 20px;
-      height: 20px;
-    }
+  &:disabled {
+    cursor: text;
   }
 }
 

--- a/src/renderer/router/index.js
+++ b/src/renderer/router/index.js
@@ -2,6 +2,7 @@ import Vue from 'vue'
 import Router from 'vue-router'
 
 import About from '@/pages/About'
+import Options from '@/pages/Options'
 import Portal from '@/pages/Portal'
 import Profiles from '@/pages/Profiles'
 import Saves from '@/pages/Saves'
@@ -13,6 +14,10 @@ const router = new Router({
     {
       path: '/about',
       component: About,
+    },
+    {
+      path: '/options',
+      component: Options,
     },
     {
       path: '/portal',

--- a/src/renderer/scss/button.scss
+++ b/src/renderer/scss/button.scss
@@ -1,8 +1,7 @@
-button {
+button, .btn {
   height: $standard-input-height;
-}
+  width: auto;
 
-.btn {
   background-color: $element-background-color;
   color: $text-primary-color;
 

--- a/src/renderer/scss/input.scss
+++ b/src/renderer/scss/input.scss
@@ -3,18 +3,17 @@ label {
   position: relative;
 }
 
-input, select {
+form button, input, select {
   box-sizing: border-box;
   height: $standard-input-height;
   font-size: 16px;
+  font-weight: normal;
 
   padding: 0 10px;
   border: 1px solid $element-background-color;
 }
 
 select {
-
-
   background-color: $element-background-color;
   font-weight: bold;
 
@@ -36,7 +35,7 @@ input[type="checkbox"] {
   vertical-align: middle;
 }
 
-input[type="text"], input[type="search"] {
+form button, input[type="text"], input[type="search"] {
   background-color: $background-primary-color;
   border-color: $highlight-color;
   color: $text-light-color;
@@ -75,3 +74,42 @@ input[type="search"] {
     &.x { opacity: 0; }
   }
 }
+
+form {
+  label {
+    font-size: 0.95rem;
+  }
+
+  button {
+    background-color: $background-secondary-color;
+    height: 32px;
+    padding: 0 20px;
+  }
+
+  .input-group {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    flex-wrap: wrap;
+
+    &:not(:first-of-type) {
+      margin-top: 10px;
+    }
+
+    label {
+      width: 100%;
+      padding: 5px;
+      border: 1px solid $highlight-color {
+        bottom: none;
+      }
+    }
+
+    input {
+      flex-grow: 1;
+      margin-top: 0;
+      margin-bottom: 0;
+    }
+  }
+}
+
+

--- a/src/renderer/scss/input.scss
+++ b/src/renderer/scss/input.scss
@@ -10,7 +10,7 @@ form button, input, select {
   font-weight: normal;
 
   padding: 0 10px;
-  border: 1px solid $element-background-color;
+  border: 2px solid $element-background-color;
 }
 
 select {
@@ -82,7 +82,7 @@ form {
 
   button {
     background-color: $background-secondary-color;
-    height: 32px;
+    height: 34px;
     padding: 0 20px;
   }
 
@@ -92,6 +92,9 @@ form {
     align-items: center;
     flex-wrap: wrap;
 
+    border-top-right-radius: 4px;
+    overflow: hidden;
+
     &:not(:first-of-type) {
       margin-top: 10px;
     }
@@ -99,7 +102,7 @@ form {
     label {
       width: 100%;
       padding: 5px;
-      border: 1px solid $highlight-color {
+      border: 2px solid $highlight-color {
         bottom: none;
       }
     }
@@ -108,6 +111,16 @@ form {
       flex-grow: 1;
       margin-top: 0;
       margin-bottom: 0;
+
+      border-top-width: 1px;
+    }
+
+    button {
+      border-width: 2px;
+      border-top-width: 1px;
+      border-right: none;
+
+      height: 33px;
     }
   }
 }

--- a/src/renderer/store/actions.js
+++ b/src/renderer/store/actions.js
@@ -163,3 +163,7 @@ export const exportProfile = ({ dispatch, state }) => {
 export const importProfile = ({ dispatch, state }) => {
   return ipcRenderer.invoke('IMPORT_PROFILE')
 }
+
+export const updateOption = ({ commit }, { name, value }) => {
+  ipcRenderer.send('UPDATE_OPTION', { name, value })
+}

--- a/src/renderer/store/actions.js
+++ b/src/renderer/store/actions.js
@@ -167,3 +167,7 @@ export const importProfile = ({ dispatch, state }) => {
 export const updateOption = ({ commit }, { name, value }) => {
   ipcRenderer.send('UPDATE_OPTION', { name, value })
 }
+
+export const promptNewFactorioPath = (_, name) => {
+  ipcRenderer.send('PROMPT_NEW_FACTORIO_PATH', name)
+}

--- a/src/renderer/store/index.js
+++ b/src/renderer/store/index.js
@@ -48,6 +48,7 @@ const state = {
     },
   },
   appLatestVersion: undefined,
+  paths: {},
   options: {},
 }
 

--- a/src/renderer/store/index.js
+++ b/src/renderer/store/index.js
@@ -48,6 +48,7 @@ const state = {
     },
   },
   appLatestVersion: undefined,
+  options: {},
 }
 
 Vue.use(Vuex)

--- a/src/renderer/store/mutations.js
+++ b/src/renderer/store/mutations.js
@@ -78,7 +78,9 @@ export const SET_APP_LATEST_VERSION = (state, { version }) => {
 }
 
 export const UPDATE_OPTIONS = (state, { options }) => {
-  for (const key in options) {
-    state.options[key] = options[key]
-  }
+  state.options = Object.assign({}, state.options, options)
+}
+
+export const UPDATE_FACTORIO_PATHS = (state, { paths }) => {
+  state.paths = Object.assign({}, state.paths, paths)
 }

--- a/src/renderer/store/mutations.js
+++ b/src/renderer/store/mutations.js
@@ -76,3 +76,9 @@ export const HIDE_MODAL = (state) => {
 export const SET_APP_LATEST_VERSION = (state, { version }) => {
   state.appLatestVersion = version
 }
+
+export const UPDATE_OPTIONS = (state, { options }) => {
+  for (const key in options) {
+    state.options[key] = options[key]
+  }
+}

--- a/src/shared/migrations/index.js
+++ b/src/shared/migrations/index.js
@@ -6,28 +6,36 @@ import logger from '@lib/logger'
 
 export const config = {
   '>=2.1.1': store => {
-    logger.info('Beginning store migration >=2.1.1')
+    try {
+      logger.info('Beginning store migration >=2.1.1')
 
-    const newFolderPath = join(app.getPath('userData'), 'data')
-    const configFilePath = join(app.getPath('userData'), 'config.json')
-    const newConfigFilePath = join(newFolderPath, 'config.json')
+      const newFolderPath = join(app.getPath('userData'), 'data')
+      const configFilePath = join(app.getPath('userData'), 'config.json')
+      const newConfigFilePath = join(newFolderPath, 'config.json')
 
-    if (existsSync(configFilePath)) {
-      logger.info(`Attempting to move config file in new data folder`)
+      if (existsSync(configFilePath)) {
+        logger.info(`Attempting to move config file in new data folder`)
 
-      mkdirSync(newFolderPath, { recursive: true })
-      copyFileSync(configFilePath, newConfigFilePath)
-      unlinkSync(configFilePath)
+        mkdirSync(newFolderPath, { recursive: true })
+        copyFileSync(configFilePath, newConfigFilePath)
+        unlinkSync(configFilePath)
 
-      logger.info('Successfully moved config file into data folder')
+        logger.info('Successfully moved config file into data folder')
+      }
+
+      logger.info('clearing old data in config file')
+      store.delete('mods.online')
+      store.delete('mods.onlineCount')
+      store.delete('mods.onlineLastFetch')
+
+      logger.info('updating values in config file')
+      store.set('options.onlinePollingInterval', 1)
+
+      logger.info('Finished store migration >=2.1.1')
+    } catch (error) {
+      logger.error(`Error during migration: ${error.message}`)
+      throw error
     }
-
-    logger.info('clearing old data in config file')
-    store.delete('mods.online')
-    store.delete('mods.onlineCount')
-    store.delete('mods.onlineLastFetch')
-
-    logger.info('Finished store migration >=2.1.1')
   },
 }
 

--- a/src/shared/migrations/index.js
+++ b/src/shared/migrations/index.js
@@ -1,0 +1,34 @@
+import { copyFileSync, existsSync, mkdirSync, unlinkSync } from 'fs'
+import { join } from 'path'
+import { app } from 'electron'
+
+import logger from '@lib/logger'
+
+export const config = {
+  '>=2.1.1': store => {
+    logger.info('Beginning store migration >=2.1.1')
+
+    const newFolderPath = join(app.getPath('userData'), 'data')
+    const configFilePath = join(app.getPath('userData'), 'config.json')
+    const newConfigFilePath = join(newFolderPath, 'config.json')
+
+    if (existsSync(configFilePath)) {
+      logger.info(`Attempting to move config file in new data folder`)
+
+      mkdirSync(newFolderPath, { recursive: true })
+      copyFileSync(configFilePath, newConfigFilePath)
+      unlinkSync(configFilePath)
+
+      logger.info('Successfully moved config file into data folder')
+    }
+
+    logger.info('clearing old data in config file')
+    store.delete('mods.online')
+    store.delete('mods.onlineCount')
+    store.delete('mods.onlineLastFetch')
+
+    logger.info('Finished store migration >=2.1.1')
+  },
+}
+
+export const onlineModsCache = {}

--- a/src/shared/models/index.js
+++ b/src/shared/models/index.js
@@ -1,4 +1,6 @@
 import mods from './mods'
+import onlineMods from './online_mods'
+import options from './options'
 import paths from './paths'
 import player from './player'
 import profiles from './profiles'
@@ -6,6 +8,8 @@ import window from './window'
 
 export default {
   mods,
+  onlineMods,
+  options,
   profiles,
   paths,
   player,

--- a/src/shared/models/mods.js
+++ b/src/shared/models/mods.js
@@ -1,4 +1,4 @@
-import { definitionsInstalledMod, definitionsOnlineMod } from './_shared'
+import { definitionsInstalledMod } from './_shared'
 import { version } from './_validators'
 
 export default {
@@ -11,20 +11,6 @@ export default {
         ...definitionsInstalledMod,
       },
       default: [],
-    },
-    online: {
-      type: 'array',
-      items: {
-        ...definitionsOnlineMod,
-      },
-      default: [],
-    },
-    onlineCount: {
-      type: 'number',
-      default: 0,
-    },
-    onlineLastFetch: {
-      type: 'number',
     },
     factorioVersion: {
       type: 'string',

--- a/src/shared/models/online_mods.js
+++ b/src/shared/models/online_mods.js
@@ -16,5 +16,5 @@ export default {
     lastFetch: {
       type: 'number',
     },
-  }
+  },
 }

--- a/src/shared/models/online_mods.js
+++ b/src/shared/models/online_mods.js
@@ -1,0 +1,20 @@
+import { definitionsOnlineMod } from './_shared'
+
+export default {
+  type: 'object',
+  default: {},
+  properties: {
+    mods: {
+      type: 'array',
+      items: { ...definitionsOnlineMod },
+      default: [],
+    },
+    count: {
+      type: 'number',
+      default: 0,
+    },
+    lastFetch: {
+      type: 'number',
+    },
+  }
+}

--- a/src/shared/models/options.js
+++ b/src/shared/models/options.js
@@ -10,7 +10,7 @@ export default {
     // How long before last check of online mods before the app will check again. In milliseconds.
     onlinePollingInterval: {
       type: 'number',
-      default: 86400000,
+      default: 1,
     },
   },
 }

--- a/src/shared/models/options.js
+++ b/src/shared/models/options.js
@@ -1,0 +1,16 @@
+export default {
+  type: 'object',
+  default: {},
+  properties: {
+    // Whether the app will close when Factorio is started through the app
+    closeOnStartup: {
+      type: 'boolean',
+      default: true,
+    },
+    // How long before last check of online mods before the app will check again. In milliseconds.
+    onlinePollingInterval: {
+      type: 'number',
+      default: 86400000,
+    },
+  },
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1348,12 +1348,22 @@ ajv-keywords@^3.1.0, ajv-keywords@^3.4.1:
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.4.1.tgz#ef916e271c64ac12171fd8384eaae6b2345854da"
   integrity sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ==
 
-ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.5.5:
+ajv@^6.1.0, ajv@^6.10.2, ajv@^6.5.5:
   version "6.10.2"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.10.2.tgz#d3cea04d6b017b2894ad69040fec8b623eb4bd52"
   integrity sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==
   dependencies:
     fast-deep-equal "^2.0.1"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.4.1"
+    uri-js "^4.2.2"
+
+ajv@^6.10.0:
+  version "6.12.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.0.tgz#06d60b96d87b8454a5adaba86e7854da629db4b7"
+  integrity sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==
+  dependencies:
+    fast-deep-equal "^3.1.1"
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
@@ -2419,17 +2429,20 @@ condense-newlines@^0.2.1:
     is-whitespace "^0.3.0"
     kind-of "^3.0.2"
 
-conf@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/conf/-/conf-5.0.0.tgz#6530308a36041bf010ab96b05a0f4aff5101c65d"
-  integrity sha512-lRNyt+iRD4plYaOSVTxu1zPWpaH0EOxgFIR1l3mpC/DGZ7XzhoGFMKmbl54LAgXcSu6knqWgOwdINkqm58N85A==
+conf@^6.2.1:
+  version "6.2.4"
+  resolved "https://registry.yarnpkg.com/conf/-/conf-6.2.4.tgz#49d23c4e21ef2ac2860f7b5ed25b7b7e484f769f"
+  integrity sha512-GjgyPRLo1qK1LR9RWAdUagqo+DP18f5HWCFk4va7GS+wpxQTOzfuKTwKOvGW2c01/YXNicAyyoyuSddmdkBzZQ==
   dependencies:
-    ajv "^6.10.0"
+    ajv "^6.10.2"
+    debounce-fn "^3.0.1"
     dot-prop "^5.0.0"
     env-paths "^2.2.0"
-    json-schema-typed "^7.0.0"
+    json-schema-typed "^7.0.1"
     make-dir "^3.0.0"
+    onetime "^5.1.0"
     pkg-up "^3.0.1"
+    semver "^6.2.0"
     write-file-atomic "^3.0.0"
 
 config-chain@^1.1.11, config-chain@^1.1.12:
@@ -2718,6 +2731,13 @@ de-indent@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/de-indent/-/de-indent-1.0.2.tgz#b2038e846dc33baa5796128d0804b455b8c1e21d"
   integrity sha1-sgOOhG3DO6pXlhKNCAS0VbjB4h0=
+
+debounce-fn@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/debounce-fn/-/debounce-fn-3.0.1.tgz#034afe8b904d985d1ec1aa589cd15f388741d680"
+  integrity sha512-aBoJh5AhpqlRoHZjHmOzZlRx+wz2xVwGL9rjs+Kj0EWUrL4/h4K7OD176thl2Tdoqui/AaA4xhHrNArGLAaI3Q==
+  dependencies:
+    mimic-fn "^2.1.0"
 
 debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
@@ -3014,9 +3034,9 @@ dot-prop@^4.1.0:
     is-obj "^1.0.0"
 
 dot-prop@^5.0.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-5.1.0.tgz#bdd8c986a77b83e3fca524e53786df916cabbd8a"
-  integrity sha512-n1oC6NBF+KM9oVXtjmen4Yo7HyAVWV2UUl50dCYJdw2924K6dX9bf9TTTWaKtYlRn0FEtxG27KS80ayVLixxJA==
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-5.2.0.tgz#c34ecc29556dc45f1f4c22697b6f4904e0cc4fcb"
+  integrity sha512-uEUyaDKoSQ1M4Oq8l45hSE26SnTxL6snNnqvK/VWx5wJhmff5z0FUVJDKDanor/6w3kzE3i7XZOk+7wC0EXr1A==
   dependencies:
     is-obj "^2.0.0"
 
@@ -3105,13 +3125,13 @@ electron-publish@21.2.0:
     lazy-val "^1.0.4"
     mime "^2.4.4"
 
-electron-store@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/electron-store/-/electron-store-4.0.0.tgz#5f0835663bb774d5eecb5b283b390f9910ec4cfc"
-  integrity sha512-qgkDetwB9bz+ZA7mNCQGm6zLJOMT4yBkTZ7f16M9iS0GcI/bOeOeFkLkIaJddTtPca7MOiaUM1imMjFqUfQgSA==
+electron-store@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/electron-store/-/electron-store-5.1.1.tgz#3040e5b4ad25d2e4caea59d505646c1e7c94a09b"
+  integrity sha512-FLidOVE8JVCdJXHd7xY/JojKJ2r2WNmWt0O/LlX2LuSVV7dkG2RSy2/Gm2LFw8OKDfrNBd9c/s4X1ikMrJEUKg==
   dependencies:
-    conf "^5.0.0"
-    type-fest "^0.5.2"
+    conf "^6.2.1"
+    type-fest "^0.7.1"
 
 electron-to-chromium@^1.3.191:
   version "1.3.226"
@@ -3686,15 +3706,15 @@ fast-deep-equal@^2.0.1:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
   integrity sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=
 
-fast-json-stable-stringify@2.x:
+fast-deep-equal@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz#545145077c501491e33b15ec408c294376e94ae4"
+  integrity sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==
+
+fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
-
-fast-json-stable-stringify@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
-  integrity sha1-1RQsDK7msRifh9OnYREGT4bIu/I=
 
 fast-levenshtein@~2.0.4:
   version "2.0.6"
@@ -5481,10 +5501,10 @@ json-schema-traverse@^0.4.1:
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
   integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
 
-json-schema-typed@^7.0.0:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/json-schema-typed/-/json-schema-typed-7.0.1.tgz#5e56564b5a0950423e22b285a30ade219e38084d"
-  integrity sha512-IqUK+Cqc8/MqHsCvv1TMccbKdBzoATOLHXZAF5UDu70/CCxo648cHUig24hc+XTK53TyeNk1UeVTlc2Haovtsw==
+json-schema-typed@^7.0.1:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/json-schema-typed/-/json-schema-typed-7.0.3.tgz#23ff481b8b4eebcd2ca123b4fa0409e66469a2d9"
+  integrity sha512-7DE8mpG+/fVw+dTpjbxnx47TaMnDfOI1jwft9g1VybltZCduyRQPJPvc+zzKY9WPHxhPWczyFuYa6I8Mw4iU5A==
 
 json-schema@0.2.3:
   version "0.2.3"
@@ -5790,9 +5810,9 @@ make-dir@^2.0.0, make-dir@^2.1.0:
     semver "^5.6.0"
 
 make-dir@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-3.0.0.tgz#1b5f39f6b9270ed33f9f054c5c0f84304989f801"
-  integrity sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw==
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-3.0.2.tgz#04a1acbf22221e1d6ef43559f43e05a90dbb4392"
+  integrity sha512-rYKABKutXa6vXTXhoV18cBE7PaewPXHe/Bdq4v+ZLMhxbWApkFFplT0LcbMW+6BbjnQXzZ/sAvSE/JdguApG5w==
   dependencies:
     semver "^6.0.0"
 
@@ -6515,9 +6535,9 @@ p-limit@^1.1.0:
     p-try "^1.0.0"
 
 p-limit@^2.0.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.2.0.tgz#417c9941e6027a9abcba5092dd2904e255b5fbc2"
-  integrity sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.3.0.tgz#3dd33c647a214fdfffd835933eb086da0dc21db1"
+  integrity sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==
   dependencies:
     p-try "^2.0.0"
 
@@ -7736,10 +7756,15 @@ sigmund@^1.0.1:
   resolved "https://registry.yarnpkg.com/sigmund/-/sigmund-1.0.1.tgz#3ff21f198cad2175f9f3b781853fd94d0d19b590"
   integrity sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=
 
-signal-exit@^3.0.0, signal-exit@^3.0.2:
+signal-exit@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
   integrity sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=
+
+signal-exit@^3.0.2:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.3.tgz#a1410c2edd8f077b08b4e253c8eacfcaf057461c"
+  integrity sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==
 
 simple-swizzle@^0.2.2:
   version "0.2.2"
@@ -8431,6 +8456,11 @@ type-fest@^0.5.2:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.5.2.tgz#d6ef42a0356c6cd45f49485c3b6281fc148e48a2"
   integrity sha512-DWkS49EQKVX//Tbupb9TFa19c7+MK1XmzkrZUR8TAktmE/DizXoaoJV6TZ/tSIPXipqNiRI6CyAe7x69Jb6RSw==
 
+type-fest@^0.7.1:
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.7.1.tgz#8dda65feaf03ed78f0a3f9678f1869147f7c5c48"
+  integrity sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg==
+
 type-fest@^0.8.0:
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
@@ -9103,9 +9133,9 @@ write-file-atomic@^2.0.0:
     signal-exit "^3.0.2"
 
 write-file-atomic@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-3.0.0.tgz#1b64dbbf77cb58fd09056963d63e62667ab4fb21"
-  integrity sha512-EIgkf60l2oWsffja2Sf2AL384dx328c0B+cIYPTQq5q2rOYuDV00/iPFBOUiDKKwKMOhkymH8AidPaRvzfxY+Q==
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-3.0.3.tgz#56bd5c5a5c70481cd19c571bd39ab965a5de56e8"
+  integrity sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==
   dependencies:
     imurmurhash "^0.1.4"
     is-typedarray "^1.0.0"


### PR DESCRIPTION
- Added options page to display app options. Includes the following options:
  - Whether to close the app when starting Factorio
  - How long to keep cached online mods before refreshing it, when viewing the mod portal page
  - All of the existing paths that were originally only set during first app initialization. They can now be changed at any time

- Added links on the options page to paths in the user filesystem where app data is stored
- Moved the data for cached online mods into a separate folder to remove clutter from main config file

Implements #119 